### PR TITLE
Added SIGKILL to process.kill

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -268,14 +268,17 @@ var force_stop = function(repo_id, callback) {
             return;
         }
         try {
-            pid = pid.replace('\n', '');
-            pid = parseInt(pid, 1000);
+            console.log('PID: "' + pid + '"');
+            pid = pid.replace(/\n/g, '').replace(/\r/g, '');
+            pid = parseInt(pid);
             if (pid > 0) {
-                process.kill(pid);
+		        console.log('Sending SIGKILL to ', pid);
+                process.kill(pid, 'SIGKILL');
                 callback(true);
             } else {
                 callback(false);
             }
+            
         } catch (e) {
             callback(false);
         }


### PR DESCRIPTION
I added SIGKILL to process.kill to make sure the process is killed and ensured that the pid returned from the force_stop method was actually a number. On AWS it came back as a string with /n/r/n/r appended to it.
