### PR TITLE
Add X-Forwarded-For headers to avail client IP to apps behind proxy

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,8 +20,8 @@ process.on('uncaughtException', function (err) {
 var myapp = express.createServer();
 
 myapp.configure(function(){
-  myapp.use(express.bodyDecoder());
-  myapp.use(express.staticProvider(config.opt.public_html_dir));
+  myapp.use(express.bodyParser());
+  myapp.use(express.static(config.opt.public_html_dir));
   myapp.use(middle.error());
 });
 

--- a/lib/3rdparty/node-http-proxy.js
+++ b/lib/3rdparty/node-http-proxy.js
@@ -198,7 +198,10 @@ HttpProxy.prototype = {
       // but this is a hot-fix because I don't think 'pool'
       // should be emitting this event.
     });
-    
+
+    // Add X-Forwarded-For headers to avail client IP to apps behind proxy
+    req.headers["X-Forwarded-For"] = req.connection.remoteAddress;
+
     p.request(req.method, req.url, req.headers, function (reverse_proxy) {
       // Create an error handler so we can use it temporarily
       function error (obj) {
@@ -279,7 +282,10 @@ HttpProxy.prototype = {
       // but this is a hot-fix because I don't think 'pool'
       // should be emitting this event.
     });
-    
+	
+    // Add X-Forwarded-For headers to avail client IP to apps behind proxy
+    req.headers["X-Forwarded-For"] = req.connection.remoteAddress;
+
     p.request(req.method, req.url, req.headers, function (forward_proxy) {
       // Add a listener for the connection timeout event
       forward_proxy.addListener('error', function (err) {


### PR DESCRIPTION
I was working on a node app involving GeoIP, only hiccup - remoteAddress is always 127.0.0.1 because of the proxy.
So added the standard "X-Forwarded-For" header to tackle the situation.

TODO: need to also commit against https://github.com/nodejitsu/node-http-proxy/issues#issue/23
