### PR TITLE
Git post-receive hook symlink'ed instead of making a copy

### DIFF
--- a/scripts/gitreposetup.sh
+++ b/scripts/gitreposetup.sh
@@ -15,7 +15,7 @@ fi;
 mkdir -p ${APPDIR}/${APPUSERNAME}/${REV}.git;
 cd ${APPDIR}/${APPUSERNAME}/${REV}.git;
 git init --bare;
-cp ${BASEDIR}/scripts/gitrepoclone.sh hooks/post-receive;
-chmod +x hooks/post-receive;
+ln -s ${BASEDIR}/scripts/gitrepoclone.sh hooks/post-receive;
+# chmod +x hooks/post-receive;
 
 git clone . ../${REV}/;


### PR DESCRIPTION
This small diff ensures that changes to gitrepoclone.sh are immediately active for all repos.
