### PR TITLE
Edited lib/middle.js via GitHub

### DIFF
--- a/lib/middle.js
+++ b/lib/middle.js
@@ -68,7 +68,7 @@ var authenticate_app = function(req, res, next) {
     db.get(appname, function (err, doc) {
       if (err) {
         res.writeHead(400, { 'Content-Type': 'application/json' });
-        res.end('{"status" : "failure - app not found (" + appname + ")"}\n');
+        res.end('{"status" : "failure - app not found (' + appname + ')"}\n');
       } else {
         if (doc.username == req.user._id) {
           req.appname = appname;
@@ -76,7 +76,7 @@ var authenticate_app = function(req, res, next) {
           next();
         } else {
           res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end('{"status" : "failure - authentication for " + appname + " failed."}\n');
+          res.end('{"status" : "failure - authentication for ' + appname + ' failed."}\n');
         }
       }
     });


### PR DESCRIPTION
As Notified by @tracend, the Delete App API for nodester does not seem to work.

`curl -X DELETE -u "user:pass" -d "appname=my_app" http://api.nodester.com/app`
returns
`{"status" : "failure - app not found (" + appname + ")"}`

The quotes seem to be improperly used because of which appname doesn`t get substituted with my_app
