### PR TITLE
CoffeeScript support

### DIFF
--- a/install.txt
+++ b/install.txt
@@ -14,6 +14,7 @@ Dependencies:
     forever
     cradle
     colored
+    coffee-script
 
 Installation:
   Install node.js (0.4.x recommended)
@@ -70,7 +71,7 @@ Installation:
   Either install CouchDB or get a CouchOne account
 
   Install node-module dependencies
-    for X in pool express npm-wrapper request daemon forever cradle colored; do npm install ${X}; done
+    for X in pool express npm-wrapper request daemon forever cradle colored coffee-script; do npm install ${X}; done
   
   Get nodester
     cd ~

--- a/scripts/chroot_runner.js
+++ b/scripts/chroot_runner.js
@@ -107,7 +107,7 @@ var myPid = daemon.start();
     });
 
     var start_child = function () {
-      child = spawn('/usr/bin/node', args, { env: env });
+      child = spawn((path.extname(args[0]) == '.coffee' ? '/usr/bin/coffee' : '/usr/bin/node'), args, { env: env });
       child.stdout.on('data', log_line.bind('stdout'));
       child.stderr.on('data', log_line.bind('stderr'));
       child.on('exit', function (code) {

--- a/scripts/chroot_runner.js
+++ b/scripts/chroot_runner.js
@@ -107,7 +107,7 @@ var myPid = daemon.start();
     });
 
     var start_child = function () {
-      child = spawn((path.extname(args[0]) == '.coffee' ? '../../bin/coffee' : '/usr/bin/node'), args, { env: env });
+      child = spawn((path.extname(args[0]) == '.coffee' ? '/usr/bin/coffee' : '/usr/bin/node'), args, { env: env });
       child.stdout.on('data', log_line.bind('stdout'));
       child.stderr.on('data', log_line.bind('stderr'));
       child.on('exit', function (code) {

--- a/scripts/chroot_runner.js
+++ b/scripts/chroot_runner.js
@@ -107,7 +107,7 @@ var myPid = daemon.start();
     });
 
     var start_child = function () {
-      child = spawn((path.extname(args[0]) == '.coffee' ? '/usr/bin/coffee' : '/usr/bin/node'), args, { env: env });
+      child = spawn((path.extname(args[0]) == '.coffee' ? '../../bin/coffee' : '/usr/bin/node'), args, { env: env });
       child.stdout.on('data', log_line.bind('stdout'));
       child.stderr.on('data', log_line.bind('stderr'));
       child.on('exit', function (code) {


### PR DESCRIPTION
There was one trivial change (plus one in the documentation) that needed to be made in order for CoffeeScript to be supported, as requested in Issue #102.

As was suggested, CoffeeScript support is done by checking the file extension of the start file: if it's '.coffee', then the `/usr/bin/coffee` executable is used instead of `/usr/bin/node`.

NPM-installed packages that are written in CoffeeScript are _supposed_ to be compiled to JavaScript using their `cake` build tool before each upload to the npm repository.

One caveat: due to technical difficulties that I am having with installing Nodester (including one which is resolved in the experimental branch), I actually have **not** been able to test this personally.
