### PR TITLE
Set restart_key to be same as default in `./scripts/gitreposetup.sh`

### DIFF
--- a/example_config.js
+++ b/example_config.js
@@ -6,25 +6,25 @@ exports.opt = {
   couch_prefix: 'nodester',
   couch_tables: ['coupons', 'nodefu', 'nextport', 'apps', 'repos', 'aliasdomains', 'password_resets', 'admins'],
   home_dir: '/node/nodester/nodester',
-  app_dir: '/node/nodester/nodester',
-  git_home_dir: '/git',
-  apps_home_dir: '/app',
-  public_html_dir: '/node/nodester/nodester/public',
+  app_dir:  '/node/nodester/nodester',
+  git_home_dir:     '/git',
+  apps_home_dir:    '/app',
+  public_html_dir:  '/node/nodester/nodester/public',
   proxy_table_file: '/node/nodester/nodester/var/proxy_table.json',
   logs_dir: '/node/logs/',
-  tl_dom: 'testnodester.com',
-  api_dom: 'api.testnodester.com',
+  tl_dom:   'testnodester.com',
+  api_dom:  'api.testnodester.com',
+  git_dom:  'testnodester.com',
   git_user: 'nodester',
-  git_dom: 'testnodester.com',
   coupon_code: 'CouponCode',
   blocked_apps: ['www', 'api', 'admin', 'support', 'blog', 'site'],
-  restart_key: 'KeepThisSecret',
+  restart_key: 'PleaseRestartMyAppMKey', // keep this secret, and make sure it matches what is in ./scripts/gitreposetup.sh
   userid: 'nodester',
   app_uid: 100,
   enable_ssl: false, // Currently SSL forward to the app/api, when I have a wildcard cert to test, then all apps can have SSL.
-  ssl_ca_file: '',
+  ssl_ca_file:   '',
   ssl_cert_file: '',
-  ssl_key_file: '',
+  ssl_key_file:  '',
   node_base_folder: '',
 
   redis: {
@@ -38,7 +38,7 @@ exports.opt = {
   //Amazon SES mail info
   SES: {
     AWSAccessKeyID: 'ACCESSKEY',
-    AWSSecretKey: 'SECRETKEY',
-    ServiceUrl: 'https://email.us-east-1.amazonaws.com',
+    AWSSecretKey:   'SECRETKEY',
+    ServiceUrl:     'https://email.us-east-1.amazonaws.com',
   }
 };


### PR DESCRIPTION
This change helps to make a new install work out of the box. Also reorder a couple of the parameters so that domain name params are all together. clean up spacing.
