### PR TITLE
Typo on default secretkey for git clone

### DIFF
--- a/scripts/example_gitrepoclone.sh
+++ b/scripts/example_gitrepoclone.sh
@@ -15,7 +15,7 @@ echo -e "\033[33m\033[1m
 echo ""
 echo ""
 
-SECRETKEY=PleaseRestartMyAppMKay
+SECRETKEY=PleaseRestartMyAppMKey
 GITBASE=/git
 APPSBASE=/app
 


### PR DESCRIPTION
Just a little typo fixed to prevent clone errors if default key is not updated when installing.
