### PR TITLE
Removes username check which doesn't do any good

### DIFF
--- a/lib/user.js
+++ b/lib/user.js
@@ -69,12 +69,6 @@ User.put = function (req, res, next) {
       },400);
       return true;
     } 
-    if (user.match(/^[a-z0-9]+$/i) === null){
-      res.json({
-        status: "failure - invalid username. must be alphanumeric"
-      },400);
-      return true;
-    }
     var db = lib.get_couchdb_database('nodefu');
     db.get(user._id, function (err, doc) {
       if (err) {


### PR DESCRIPTION
The username is already checked at https://github.com/nodester/nodester/blob/75cbc48b7d/lib/user.js#L136-140 during user creation, and since change of username isn't possible, it doesn't make sense to check the username anywhere else since it's part of the authentication.
